### PR TITLE
Sync all license text

### DIFF
--- a/src/classes/reports/report.eventlog.auditsummary.class.php
+++ b/src/classes/reports/report.eventlog.auditsummary.class.php
@@ -12,15 +12,24 @@
 	-----------------------------------------------------------------
 	Copyright (c) 2012, Adiscon GmbH. All rights reserved.
 
-	No fee is required for NON-COMMERCIAL use; however, commercial use is not permitted under this license.
+        * This file is part of LogAnalyzer.
+        *
+        * LogAnalyzer is free software: you can redistribute it and/or modify
+        * it under the terms of the GNU General Public License as published by
+        * the Free Software Foundation, either version 3 of the License, or
+        * (at your option) any later version.
+        *
+        * LogAnalyzer is distributed in the hope that it will be useful,
+        * but WITHOUT ANY WARRANTY; without even the implied warranty of
+        * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        * GNU General Public License for more details.
+        *
+        * You should have received a copy of the GNU General Public License
+        * along with LogAnalyzer. If not, see <http://www.gnu.org/licenses/>.
+        *
+        * A copy of the GPL can be found in the file "COPYING" in this
+        * distribution.
 
-	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-		* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-		* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-		* Any redistribution, use, or modification is licensed solely for  NON-COMMERCIAL purposes. Commercial use requires a commercial license. If in doubt, commercial use is any use by a for-profit or government organization.  Non-commercial use is assumed for personal use and use in public schools and universities and tax-exempt charities. If in doubt, inquire at info@adiscon.com with a description of your intended use.
-	 
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	-----------------------------------------------------------------
 */
 

--- a/src/classes/reports/report.eventlog.auditsummary/report.eventlog.auditsummary.lang.en.php
+++ b/src/classes/reports/report.eventlog.auditsummary/report.eventlog.auditsummary.lang.en.php
@@ -7,15 +7,24 @@
 	-----------------------------------------------------------------
 	Copyright (c) 2012, Adiscon GmbH. All rights reserved.
 
-	No fee is required for NON-COMMERCIAL use; however, commercial use is not permitted under this license.
+        * This file is part of LogAnalyzer.
+        *
+        * LogAnalyzer is free software: you can redistribute it and/or modify
+        * it under the terms of the GNU General Public License as published by
+        * the Free Software Foundation, either version 3 of the License, or
+        * (at your option) any later version.
+        *
+        * LogAnalyzer is distributed in the hope that it will be useful,
+        * but WITHOUT ANY WARRANTY; without even the implied warranty of
+        * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        * GNU General Public License for more details.
+        *
+        * You should have received a copy of the GNU General Public License
+        * along with LogAnalyzer. If not, see <http://www.gnu.org/licenses/>.
+        *
+        * A copy of the GPL can be found in the file "COPYING" in this
+        * distribution.
 
-	Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-		* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-		* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-		* Any redistribution, use, or modification is licensed solely for  NON-COMMERCIAL purposes. Commercial use requires a commercial license. If in doubt, commercial use is any use by a for-profit or government organization.  Non-commercial use is assumed for personal use and use in public schools and universities and tax-exempt charities. If in doubt, inquire at info@adiscon.com with a description of your intended use.
-	 
-	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	-----------------------------------------------------------------
 */
 global $content;


### PR DESCRIPTION
When you inserted GPL terms into all the files, it looks like these two were missed.  You can use this pull request to sync them, I just copied the corresponding text from one of the other files.
