### PR TITLE
Fix off-by-one error in ReadNextBlock() that causes broken entries

### DIFF
--- a/src/classes/logstreamdisk.class.php
+++ b/src/classes/logstreamdisk.class.php
@@ -184,7 +184,7 @@ class LogStreamDisk extends LogStream {
 			$orig_offset -= self::_BUFFER_length;
 			if ($orig_offset <= 0) {
 				// ok, we have to adjust the buffer pointer
-				$this->_p_buffer += $orig_offset; // note orig_offset is negative, see if
+				$this->_p_buffer += $orig_offset-1; // note orig_offset is negative, see if
 				$orig_offset = 0;
 			}
 			fseek($this->_fp, $orig_offset);


### PR DESCRIPTION
This bug occurs when backwards reading the last block at beginning of file where the first character on the previous block boundary is duplicated. This corrupts syslog entries possibly breaking time strings or the message.

(Context: I found this fix on an old branch of mine back from when I used loganalyzer, I want to contribute it upstream before it gets forgotten again but am not able to provide more details than in commit message)