### PR TITLE
Incorrect value type for column

### DIFF
--- a/src/include/db_update_v9.txt
+++ b/src/include/db_update_v9.txt
@@ -2,7 +2,7 @@
 CREATE TABLE `logcon_savedreports` (
   `ID` int(11) NOT NULL auto_increment,
   `reportid` varchar(255) NOT NULL,
-  `sourceid` int(11) NOT NULL,
+  `sourceid` varchar(11) NOT NULL,
   `customTitle` varchar(255) NOT NULL,
   `customComment` text NOT NULL,
   `filterString` text NOT NULL,


### PR DESCRIPTION
int only allows numeric values
where as sources are named like: Source% 
This fails initial insert or creates a entry without Sourceid and the fails all updates.

rever to issue [#33 ](https://github.com/rsyslog/loganalyzer/issues/33)