### PR TITLE
Fix PR88 CSS issues 

### DIFF
--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -183,6 +183,7 @@ if ( isset($_POST['op']) )
 			if ( isset ($_POST['DebugUserLogin']) ) { $content['DebugUserLogin'] = 1; } else { $content['DebugUserLogin'] = 0; } 
 			if ( isset ($_POST['MiscDebugToSyslog']) ) { $content['MiscDebugToSyslog'] = 1; } else { $content['MiscDebugToSyslog'] = 0; } 
 			if ( isset ($_POST['DisableAdminUsers']) ) { $content['DisableAdminUsers'] = 1; } else { $content['DisableAdminUsers'] = 0; } 
+			if ( isset ($_POST['ViewColoredCells']) ) { $content['ViewColoredCells'] = 1; } else { $content['ViewColoredCells'] = 0; }
 
 			// Read Text number fields
 			if ( isset ($_POST['ViewMessageCharacterLimit']) && is_numeric($_POST['ViewMessageCharacterLimit']) ) { $content['ViewMessageCharacterLimit'] = $_POST['ViewMessageCharacterLimit']; }
@@ -235,6 +236,7 @@ if ( isset($_POST['op']) )
 			if ( isset ($_POST['User_DefaultFontSize']) ) { $USERCFG['DefaultFontSize'] = $_POST['User_DefaultFontSize']; }
 
 			// Read checkboxes
+			if ( isset( $_POST['User_ViewColoredCells'])  ) { $USERCFG['ViewColoredCells'] = 1; } else { $USERCFG['ViewColoredCells'] = 0; }
 			if ( isset ($_POST['User_ViewUseTodayYesterday']) ) { $USERCFG['ViewUseTodayYesterday'] = 1; } else { $USERCFG['ViewUseTodayYesterday'] = 0; } 
 			if ( isset ($_POST['User_ViewEnableDetailPopups']) ) { $USERCFG['ViewEnableDetailPopups'] = 1; } else { $USERCFG['ViewEnableDetailPopups'] = 0; } 
 			if ( isset ($_POST['User_EnableContextLinks']) ) { $USERCFG['EnableContextLinks'] = 1; } else { $USERCFG['EnableContextLinks'] = 0; } 
@@ -280,7 +282,7 @@ if ( !isset($content['AdminChangeWaitTime']) ) { $content['AdminChangeWaitTime']
 // Set checkbox States
 if (isset($content['ExportUseTodayYesterday']) && $content['ExportUseTodayYesterday'] == 1) { $content['ExportUseTodayYesterday_checked'] = "checked"; } else { $content['ExportUseTodayYesterday_checked'] = ""; }
 if (isset($content['SESSION_MAXIMIZED']) && $content['SESSION_MAXIMIZED'] == 1) { $content['SESSION_MAXIMIZED_checked'] = "checked"; } else { $content['SESSION_MAXIMIZED_checked'] = ""; }
-
+if (isset($content['ViewColoredCells']) && $content['ViewColoredCells'] == 1) { $content['ViewColoredCells_checked'] = "checked"; } else { $content['ViewColoredCells_checked'] = ""; }
 if (isset($content['ViewUseTodayYesterday']) && $content['ViewUseTodayYesterday'] == 1) { $content['ViewUseTodayYesterday_checked'] = "checked"; } else { $content['ViewUseTodayYesterday_checked'] = ""; }
 if (isset($content['ViewEnableDetailPopups']) && $content['ViewEnableDetailPopups'] == 1) { $content['ViewEnableDetailPopups_checked'] = "checked"; } else { $content['ViewEnableDetailPopups_checked'] = ""; }
 if (isset($content['EnableContextLinks']) && $content['EnableContextLinks'] == 1) { $content['EnableContextLinks_checked'] = "checked"; } else { $content['EnableContextLinks_checked'] = ""; }
@@ -398,6 +400,7 @@ if ( $content['ENABLEUSEROPTIONS'] )
 	// Set checkbox States
 	if ( GetConfigSetting('ExportUseTodayYesterday', $content['ExportUseTodayYesterday'], CFGLEVEL_USER) == 1) { $content['User_ExportUseTodayYesterday_checked'] = "checked"; } else { $content['User_ExportUseTodayYesterday_checked'] = ""; }
 	if ( GetConfigSetting('SESSION_MAXIMIZED', $content['SESSION_MAXIMIZED'], CFGLEVEL_USER) == 1) { $content['User_SESSION_MAXIMIZED_checked'] = "checked"; } else { $content['User_SESSION_MAXIMIZED_checked'] = ""; }
+	if ( GetConfigSetting('ViewColoredCells', $content['ViewColoredCells'], CFGLEVEL_USER) == 1) { $content['User_ViewColoredCells_checked'] = "checked"; } else { $content['User_ViewColoredCells_checked'] = ""; }
 
 	if ( GetConfigSetting('ViewUseTodayYesterday', $content['ViewUseTodayYesterday'], CFGLEVEL_USER) == 1) { $content['User_ViewUseTodayYesterday_checked'] = "checked"; } else { $content['User_ViewUseTodayYesterday_checked'] = ""; }
 	if ( GetConfigSetting('ViewEnableDetailPopups', $content['ViewEnableDetailPopups'], CFGLEVEL_USER) == 1) { $content['User_ViewEnableDetailPopups_checked'] = "checked"; } else { $content['User_ViewEnableDetailPopups_checked'] = ""; }

--- a/src/css/defaults.css
+++ b/src/css/defaults.css
@@ -142,3 +142,134 @@
     font-size: 1.3em;
     color: #737373;
 }
+
+/* Cells for listening */
+/*emergency*/
+.line1_0{
+	color: #000000; background-color: #840A15;
+}
+.line2_0{
+	color: #000000; background-color: #be0e1d;
+}
+.line1_0:hover, .line2_0:hover {
+	background-color:#CD636E;
+}
+td .line1_0 a, td .line1_0 a:link, td .line1_0 a:active, td .line1_0 a:visited,
+td .line2_0 a, td .line2_0 a:link, td .line2_0 a:active, td .line2_0 a:visited {
+	color: #ffffff;
+}
+/*alert*/
+.line1_1{
+	color: #000000; background-color: #BA0716;
+}
+.line2_1{
+	color: #000000; background-color: #dd081a;
+}
+.line1_1:hover, .line2_1:hover {
+	background-color:#CD636E;
+}
+td .line1_1 a, td .line1_1 a:link, td .line1_1 a:active, td .line1_1 a:visited,
+td .line2_1 a, td .line2_1 a:link, td .line2_1 a:active, td .line2_1 a:visited {
+	color: #ffffff;
+}
+/*critical*/
+.line1_2{
+	color: #000000; background-color: #CE0819;
+}
+.line2_2{
+	color: #000000; background-color: #f83a4a;
+}
+.line1_2:hover, .line2_2:hover {
+	color: #ffff55;
+	background-color:#CD636E;
+}
+td .line1_2 a, td .line1_2 a:link, td .line1_2 a:active, td .line1_2 a:visited,
+td .line2_2 a, td .line2_2 a:link, td .line2_2 a:active, td .line2_2 a:visited {
+	color: #ffffff;
+}
+/*error*/
+.line1_3{
+	color: #ffff99; background-color: #BB0A1F;
+}
+.line2_3{
+	color: #ffff99; background-color: #f20d28;
+}
+.line1_3:hover, .line2_3:hover {
+	color: #ffff55;
+	background-color:#CD636E;
+}
+td .line1_3 a, td .line1_3 a:link, td .line1_3 a:active, td .line1_3 a:visited,
+td .line2_3 a, td .line2_3 a:link, td .line2_3 a:active, td .line2_3 a:visited {
+	color: #ffffff;
+}
+/*warning*/
+.line1_4{
+	color: #000000; background-color: #EF8200;
+}
+.line2_4{
+	color: #000000; background-color: #ff8c00;
+}
+.line1_4:hover, .line2_4:hover {
+	background-color:#ffc680;
+}
+td .line1_4 a, td .line1_4 a:link, td .line1_4 a:active, td .line1_4 a:visited,
+td .line2_4 a, td .line2_4 a:link, td .line2_4 a:active, td .line2_4 a:visited {
+	color: #000000;
+}
+/*notice*/
+.line1_5{
+	color: #000000; background-color: #14AD42;
+}
+.line2_5{
+	color: #000000; background-color: #18cd4e;
+}
+.line1_5:hover, .line2_5:hover {
+	background-color:#76ef9a;
+}
+td .line1_5 a, td .line1_5 a:link, td .line1_5 a:active, td .line1_5 a:visited,
+td .line2_5 a, td .line2_5 a:link, td .line2_5 a:active, td .line2_5 a:visited {
+	color: #000000;
+}
+/*info*/
+.line1_6{
+	color: #000000; background-color: #0C9C91;
+}
+.line2_6{
+	color: #000000; background-color: #0ebeaf;
+}
+.line1_6:hover, .line2_6:hover {
+	background-color:#2aefde;
+}
+td .line1_6 a, td .line1_6 a:link, td .line1_6 a:active, td .line1_6 a:visited,
+td .line2_6 a, td .line2_6 a:link, td .line2_6 a:active, td .line2_6 a:visited {
+	color: #000000;
+}
+/*debug*/
+.line1_7{
+	color: #000000; background-color: #666699;
+}
+.line2_7{
+	color: #000000; background-color: #8585ad;
+}
+.line1_7:hover, .line2_7:hover {
+	background-color:#a3a3c2;
+}
+td .line1_7 a, td .line1_7 a:link, td .line1_7 a:active, td .line1_7 a:visited,
+td .line2_7 a, td .line2_7 a:link, td .line2_7 a:active, td .line2_7 a:visited {
+	color: #000000;
+}
+/*trace*/
+.line1_8{
+	color: #000000; background-color: #c2c2c0;
+}
+.line2_8{
+	color: #000000; background-color: #cdcdcb;
+}
+.line1_8:hover, .line2_8:hover {
+	background-color:#f3f3f2;
+	background-color:#dadad8;
+}
+td .line1_8 a, td .line1_8 a:link, td .line1_8 a:active, td .line1_8 a:visited,
+td .line2_8 a, td .line2_8 a:link, td .line2_8 a:active, td .line2_8 a:visited {
+	color: #000000;
+}

--- a/src/include/functions_common.php
+++ b/src/include/functions_common.php
@@ -1795,6 +1795,7 @@ function SaveGeneralSettingsIntoDB($bForceStripSlahes = false)
 
 	WriteConfigValue( "ExportUseTodayYesterday", true, null, null,$bForceStripSlahes );
 	WriteConfigValue( "SESSION_MAXIMIZED", true, null, null,$bForceStripSlahes );
+	WriteConfigValue( "ViewColoredCells", true, null, null,$bForceStripSlahes );
 	
 	WriteConfigValue( "ViewUseTodayYesterday", true, null, null,$bForceStripSlahes );
 	WriteConfigValue( "ViewEnableDetailPopups", true, null, null,$bForceStripSlahes );
@@ -1850,6 +1851,7 @@ function SaveUserGeneralSettingsIntoDB()
 
 	WriteConfigValue( "ExportUseTodayYesterday", false, $content['SESSION_USERID']);
 	WriteConfigValue( "SESSION_MAXIMIZED", false, $content['SESSION_USERID']);
+	WriteConfigValue( "ViewColoredCells", false, $content['SESSION_USERID']);
 	
 	WriteConfigValue( "ViewUseTodayYesterday", false, $content['SESSION_USERID'] );
 	WriteConfigValue( "ViewEnableDetailPopups", false, $content['SESSION_USERID'] );

--- a/src/include/functions_common.php
+++ b/src/include/functions_common.php
@@ -58,7 +58,10 @@ $DEBUGMODE = DEBUG_INFO;
 
 // Enable error tracking
 @ini_set( "track_errors", "On" );
-// --- 
+
+// Try to enable a little more memory in case we do some more filtering
+@ini_set('memory_limit', '512M');
+// ---
 
 // Default language
 $LANG_EN = "en";	// Used for fallback
@@ -627,20 +630,11 @@ function CheckAndSetRunMode()
 */
 function RemoveMagicQuotes()
 {
-	if(function_exists("get_magic_quotes_gpc")  && get_magic_quotes_gpc()) {
-		$process = array(&$_GET, &$_POST, &$_COOKIE, &$_REQUEST);
-		while (list($key, $val) = each($process)) {
-			foreach ($val as $k => $v) {
-				unset($process[$key][$k]);
-				if (is_array($v)) {
-					$process[$key][stripslashes($k)] = $v;
-					$process[] = &$process[$key][stripslashes($k)];
-				} else {
-					$process[$key][stripslashes($k)] = stripslashes($v);
-				}
-			}
-		}
-		unset($process);
+	if(function_exists("get_magic_quotes_gpc") && get_magic_quotes_gpc()) {
+		RemoveMagicQuotes_deep($_GET);
+		RemoveMagicQuotes_deep($_POST);
+		RemoveMagicQuotes_deep($_COOKIE);
+		RemoveMagicQuotes_deep($_REQUEST);
 	}
 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -332,6 +332,7 @@ if ( isset($content['Sources'][$currentSourceID]) )
 			// --- Obtain characters limits first!
 			$myMsgCharLimit = GetConfigSetting("ViewMessageCharacterLimit", 80, CFGLEVEL_USER);
 			$myStrCharLimit = GetConfigSetting("ViewStringCharacterLimit", 30, CFGLEVEL_USER);
+			$ViewColoredCells = GetConfigSetting("ViewColoredCells", 0, CFGLEVEL_USER);
 			// ---
 
 			//Loop through the messages!
@@ -370,10 +371,11 @@ if ( isset($content['Sources'][$currentSourceID]) )
 				// --- 
 
 				// --- Set CSS Class
+				$szCssAppend = ($ViewColoredCells == 1 ? ((isset($logArray[SYSLOG_SEVERITY]) && strlen($logArray[SYSLOG_SEVERITY]) > 0 ? "_" . $logArray[SYSLOG_SEVERITY] : "")) : "");
 				if ( $counter % 2 == 0 )
-					$content['syslogmessages'][$counter]['cssclass'] = "line1" . (isset($logArray[SYSLOG_SEVERITY]) && strlen($logArray[SYSLOG_SEVERITY]) > 0 ? "_" . $logArray[SYSLOG_SEVERITY] : "");
+					$content['syslogmessages'][$counter]['cssclass'] = "line1" . $szCssAppend;
 				else
-					$content['syslogmessages'][$counter]['cssclass'] = "line2" . (isset($logArray[SYSLOG_SEVERITY]) && strlen($logArray[SYSLOG_SEVERITY]) > 0 ? "_" . $logArray[SYSLOG_SEVERITY] : "");
+					$content['syslogmessages'][$counter]['cssclass'] = "line2" . $szCssAppend;
 				// --- 
 
 				// --- Copy other needed properties

--- a/src/lang/en/admin.php
+++ b/src/lang/en/admin.php
@@ -121,6 +121,7 @@ $content['LN_ADMIN_DEFAULTENCODING'] = "Default character encoding";
 $content['LN_GEN_CONTEXTLINKS'] = "Enable Contextlinks (Question marks)";
 $content['LN_GEN_DISABLEADMINUSERS'] = "Disable Adminpanel for normal users";
 $content['LN_GEN_SESSION_MAX'] = "Load page in maximized mode";
+$content['LN_GEN_VIEWCOLOREDCELLS'] = "Colored Syslog messages based on Syslog Severity (Priority)";
 
 // User Center
 $content['LN_USER_CENTER'] = "User Options";

--- a/src/templates/admin/admin_index.html
+++ b/src/templates/admin/admin_index.html
@@ -236,6 +236,15 @@
 <!-- ENDIF ENABLEUSEROPTIONS="true" -->
         </tr>
 
+
+	<tr>
+		<td align="left" class="cellmenu2" nowrap><b>{LN_GEN_VIEWCOLOREDCELLS}</b></td>
+		<td align="left" class="line2" ><input type="checkbox" name="ViewColoredCells" value="yes" {ViewColoredCells_checked} {DISABLE_GLOBALEDIT_FORMCONTROL}></td>
+<!-- IF ENABLEUSEROPTIONS="true" -->
+		<td align="left" class="line2" ><input type="checkbox" name="User_ViewColoredCells" value="yes" {User_ViewColoredCells_checked}></td>
+<!-- ENDIF ENABLEUSEROPTIONS="true" -->
+	</tr>
+
 	<tr>
 		<td align="left" class="cellmenu2" nowrap><b>{LN_GEN_USETODAY}</b></td>
 		<td align="left" class="line2" ><input type="checkbox" name="ViewUseTodayYesterday" value="yes" {ViewUseTodayYesterday_checked} {DISABLE_GLOBALEDIT_FORMCONTROL}></td>

--- a/src/themes/dark/main.css
+++ b/src/themes/dark/main.css
@@ -154,34 +154,32 @@ font
 	border-color: #050A0F #353A3F #353A3F #050A0F; 
 }
 
-/* Cells for listening */
-.line0
-{
+/* Style related Cells for listening */
+.ui-menu-item a, .ui-menu-item a:link, .ui-menu-item a:active, .ui-menu-item a:visited  {
+	color: #ffffff !important;
+}
+.ui-menu-item a:hover {
+	color: #ffffff !important;
+}
+.line0 {
 	color: #B9B597;
 	background-color: #0E161F;
 }
-.line0:hover 
-{ 
+.line0:hover {
 	background-color:#3D4751; 
 }
-
-.line1
-{
+.line1 {
 	color: #B9B597;
 	background-color: #152331;
 }
-.line1:hover 
-{ 
+.line1:hover {
 	background-color:#3D4751; 
 }
-
-.line2
-{
+.line2 {
 	color: #B9B597;
 	background-color: #1D3043;
-}
-.line2:hover 
-{ 
+} 
+.line2:hover {
 	background-color:#3D4751; 
 }
 

--- a/src/themes/default/main.css
+++ b/src/themes/default/main.css
@@ -3,14 +3,6 @@ body
 {
 	color: #000000;
 	background-color: #f9f9f9;
-
-	scrollbar-face-color: #DEE3E7;
-	scrollbar-highlight-color: #FFFFFF;
-	scrollbar-shadow-color: #DEE3E7;
-	scrollbar-3dlight-color: #D1D7DC;
-	scrollbar-arrow-color:  #006699;
-	scrollbar-track-color: #EFEFEF;
-	scrollbar-darkshadow-color: #98AAB1;
 }
 
 td 
@@ -34,11 +26,9 @@ a:hover
 /*---*/
 
 /* Gridline Link Classes */
-td .gridline a:link,td .gridline a:active,td .gridline a:visited,td .gridline a.postlink
-{
-        color:#ffffff;
+.gridline {
+	color:#ffffff;
 }
-
 
 /* Context Link Classes */
 a.contextlink:link,a.contextlink:active,a.contextlink:visited,a.contextlink
@@ -162,82 +152,36 @@ font
 	border-color: #44617D #203040 #203040 #44617D; 
 }
 
-/* Cells for listening */
-/*emergency*/
-.line1_0  { color: #ffffff; background-color: #840A15;}
-.line1_0:hover { background-color:#ed1224;}
-.line2_0{ color: #ffffff; background-color: #be0e1d;}
-.line2_0:hover {background-color:#f8a0a7; }
-/*alert*/
-.line1_1 { color: #ffffff; background-color: #BA0716;}
-.line1_1:hover { background-color:#f6091d;}
-.line2_1{ color: #ffffff; background-color: #dd081a;}
-.line2_1:hover {background-color:#fa6b77; }
-/*critical*/
-.line1_2 { color: #ffffff; background-color: #CE0819;}
-.line1_2:hover { background-color:#fa6b77;}
-.line2_2{ color: #ffffff; background-color: #f83a4a;}
-.line2_2:hover {background-color:#fcb5bb; }
-/*error*/
-.line1_3 { color: #ffffff; background-color: #BB0A1F;}
-.line1_3:hover { background-color:#fa9ea9;}
-.line2_3{ color: #ffffff; background-color: #f20d28;}
-.line2_3:hover {background-color:#fa9ea9; }
-/*warning*/
-.line1_4 { color: #000000; background-color: #EF8200;}
-.line1_4:hover { background-color:#ffa333;}
-.line2_4{ color: #000000; background-color: #ff8c00;}
-.line2_4:hover {background-color:#ffc680; }
-/*notice*/
-.line1_5 { color: #000000; background-color: #14AD42;}
-.line1_5:hover { background-color:#32e768;}
-.line2_5{ color: #000000; background-color: #18cd4e;}
-.line2_5:hover {background-color:#76ef9a; }
-/*info*/
-.line1_6 { color: #000000; background-color: #0C9C91;}
-.line1_6:hover { background-color:#2aefde;}
-.line2_6{ color: #000000; background-color: #0ebeaf;}
-.line2_6:hover {background-color:#2aefde; }
-/*debug*/
-.line1_7 { color: #000000; background-color: #666699;}
-.line1_7:hover { background-color:#a3a3c2;}
-.line2_7{ color: #000000; background-color: #8585ad;}
-.line2_7:hover {background-color:#a3a3c2; }
-/*trace*/
-.line1_8 { color: #000000; background-color: #c2c2c0;}
-.line1_8:hover { background-color:#dadad8;}
-.line2_8{ color: #000000; background-color: #cdcdcb;}
-.line2_8:hover {background-color:#f3f3f2; }
+/* Style related Cells for listening */
+.ui-menu-item a, .ui-menu-item a:link, .ui-menu-item a:active, .ui-menu-item a:visited  {
+	color: #000000 !important;
+}
+.ui-menu-item a:hover {
+	color: #000000 !important;
+}
 
-.line0
-{
-		color: #000000;
+.line0 {
+	color: #000000;
 	background-color: #DDDDDD;
 }
-.line0:hover 
-{ 
+.line0:hover { 
 	background-color:#F9F9F9; 
 }
-
-.line1
-{
+.line1 {
 	color: #000000;
 	background-color: #EEEEEE;
 }
-.line1:hover 
-{ 
+.line1:hover { 
+	background-color:#F9F9F9; 
+}
+.line2 {
+	color: #000000;
+	background-color: #F5F5F5;
+}
+.line2:hover { 
 	background-color:#F9F9F9; 
 }
 
-.line2
-{
-		color: #000000;
-	background-color: #F5F5F5;
-}
-.line2:hover 
-{ 
-	background-color:#F9F9F9; 
-}
 .tableBackground
 {
 		color: #000000;
@@ -483,7 +427,7 @@ select, input, button, textarea
 .highlighted 
 { 
 	font-weight: bold;
-
+	background-color: #ffffff; 
 	color: #BB0000 
 }
 

--- a/src/themes/highcontrast/main.css
+++ b/src/themes/highcontrast/main.css
@@ -15,7 +15,6 @@ a:link,a:active,a:visited,a.postlink
 {
 	font-weight: bold;
 	text-decoration:none;
-
 	background-color: transparent;
 	color:#002C5B;
 }
@@ -134,26 +133,30 @@ a.title:hover
 	border-color: #44617D #203040 #203040 #44617D; 
 }
 
-/* Cells for listening */
-.line0
-{
+/* Style related Cells for listening */
+.ui-menu-item a, .ui-menu-item a:link, .ui-menu-item a:active, .ui-menu-item a:visited  {
+	color: #000000 !important;
+}
+.ui-menu-item a:hover {
+	color: #ffffff !important;
+}
+
+.line0 {
 	color: #000000;
 	background-color: #F0F0F0;
 }
-.line1
-{
+.line1 {
 	color: #000000;
 	background-color: #E0E0E0;
 }
-.line2
-{
+.line2 {
 	color: #000000;
 	background-color: #D0D0D0;
 }
-.line0:hover, .line1:hover, .line2:hover 
-{ 
+.line0:hover, .line1:hover, .line2:hover { 
 	background-color:#F9F9F9; 
 }
+
 .tableBackground
 {
 	color: #000000;


### PR DESCRIPTION
- Fixed font colors for new css
- Moved cell css from theme to default (works for all themes)
- Fixed menu Css colors
- Added css changes to dark and highcontrast theme
- Fixed cell css for events that miss syslog severity (old format)
- Increased memory usage max
- Add new Option "ViewColoredCells" to enable / disable the new colored syslog message cells based on Syslog Severity (Priority).

see also https://github.com/rsyslog/loganalyzer/issues/88
