### PR TITLE
Update logstreamlineparsersyslogng.class.php

### DIFF
--- a/src/classes/logstreamlineparsersyslogng.class.php
+++ b/src/classes/logstreamlineparsersyslogng.class.php
@@ -69,14 +69,14 @@ require_once($gl_root_path . 'include/constants_logstream.php');
 // --- 
 
 
-class LogStreamLineParsersyslog extends LogStreamLineParser {
+class LogStreamLineParsersyslogng extends LogStreamLineParser {
 //	protected $_arrProperties = null;
 
 	// Constructor
 	public function __construct () {
 		return; // Nothing
 	}
-	public function LogStreamLineParsersyslog() {
+	public function LogStreamLineParsersyslogng() {
 		self::__construct();
 	}
 


### PR DESCRIPTION
fix for parser when syslog-ng is selected.

syslog-ng: syslog-ng 4 (4.2.0)
loganalyzer: commit: 18c40e1af541768a8a59ef0c88f475232b2e3ba5

loganalyzer config.php
`
$CFG['DefaultSourceID'] = 'Source1';
$CFG['Sources']['Source1']['ID'] = 'Source1';
$CFG['Sources']['Source1']['Name'] = 'whatever';
$CFG['Sources']['Source1']['ViewID'] = 'SYSLOG';
$CFG['Sources']['Source1']['SourceType'] = SOURCE_DISK;
$CFG['Sources']['Source1']['LogLineType'] = 'syslogng';
$CFG['Sources']['Source1']['DiskFile'] = '/var/log/syslogng.log';

**Symptoms**
`
datetime [error] xyz: *29 FastCGI sent in stderr: "PHP message: PHP Warning:  ob_start(): function &quot;ob_gzhandler&quot; not found or invalid function name in /usr/local/www/loganalyzer/include/functions_common.php on line 649; PHP message: PHP Notice:  ob_start(): Failed to create buffer in /usr/local/www/loganalyzer/include/functions_common.php on line 649; PHP message: PHP Fatal error:  Uncaught Error: Class "LogStreamLineParsersyslogng" not found in /usr/local/www/loganalyzer/classes/logstreamconfigdisk.class.php:77
Stack trace:
#0 /usr/local/www/loganalyzer/classes/logstreamconfigdisk.class.php(54): LogStreamConfigDisk->CreateLineParser()
#1 /usr/local/www/loganalyzer/index.php(234): LogStreamConfigDisk->LogStreamFactory()
#2 {main}
  thrown in /usr/local/www/loganalyzer/classes/logstreamconfigdisk.class.php on line 77" while reading response header from upstream, client: <ipaddress>, server: log.krabica.local, request: "GET /index.php HTTP/1.1", upstream: "fastcgi://unix:/var/run/php-fpm.sock:", host: "<ipaddress>", referrer: "http://<ipaddress>/install.php?step=8"
`


`


