### PR TITLE
fix #83

### DIFF
--- a/src/export.php
+++ b/src/export.php
@@ -142,6 +142,13 @@ if ( !$content['error_occured'] )
 		$stream = $stream_config->LogStreamFactory($stream_config);
 		$stream->SetFilter($content['searchstr']);
 		
+		// --- Set the maximum number of records to export
+		$maxExportRecords = GetConfigSetting("ExportMaxRecords", 10000, CFGLEVEL_GLOBAL);
+		if ($maxExportRecords == 0) {
+			// No limit - export all matching records
+			$maxExportRecords = PHP_INT_MAX;
+		}
+		
 		// Copy current used columns here!
 		$content['Columns'] = $content['Views'][$currentViewID]['Columns'];
 
@@ -286,7 +293,7 @@ if ( !$content['error_occured'] )
 
 					// Increment Counter
 					$counter++;
-				} while ($counter < $content['CurrentViewEntriesPerPage'] && ($ret = $stream->ReadNext($uID, $logArray)) == SUCCESS);
+				} while ($counter < $maxExportRecords && ($ret = $stream->ReadNext($uID, $logArray)) == SUCCESS);
 
 				if ( $content['read_direction'] == EnumReadDirection::Forward )
 				{

--- a/src/include/config.sample.php
+++ b/src/include/config.sample.php
@@ -82,6 +82,7 @@ $CFG['DebugUserLogin'] = 0;					// if enabled, you will see additional informati
 
 // --- Default Export options
 $CFG['ExportUseTodayYesterday'] = 0;                    // Same as ViewUseTodayYesterday. By default export normal dates
+$CFG['ExportMaxRecords'] = 10000;                      // Maximum number of records to export. 0 means no limit (export all matching records)
 
 // --- Default Frontend Options 
 $CFG['PrependTitle'] = "";					// If set, this	text will be prepended withint the title tag


### PR DESCRIPTION
This pull request introduces a new configuration setting to control the maximum number of records exported in the `src/export.php` file. The changes ensure that exports are limited based on this setting, improving performance and preventing excessive data handling.

### Configuration Update:
* [`src/include/config.sample.php`](diffhunk://#diff-5b121913e4bc84a16aa3dfa72588e86be000262c9144ea6221ec57856a45927dR85): Added a new configuration setting, `ExportMaxRecords`, with a default value of 10,000. This setting allows administrators to define the maximum number of records to export, with `0` indicating no limit.

### Export Logic Enhancement:
* [`src/export.php`](diffhunk://#diff-e444a5a3b69f61c56b6d468321a67fbc2d4b719feaa602d25965be1b32267996R145-R151): Introduced a variable `$maxExportRecords` to fetch the `ExportMaxRecords` configuration value. If set to `0`, it defaults to `PHP_INT_MAX` to allow unlimited exports. This ensures flexibility in export limits.
* [`src/export.php`](diffhunk://#diff-e444a5a3b69f61c56b6d468321a67fbc2d4b719feaa602d25965be1b32267996L289-R296): Updated the export loop condition to use `$maxExportRecords` instead of the previous `CurrentViewEntriesPerPage`, effectively enforcing the export limit.