### PR TITLE
Fix MkDocs output dir for GitHub Pages

### DIFF
--- a/doc-site/mkdocs.yml
+++ b/doc-site/mkdocs.yml
@@ -7,6 +7,8 @@ edit_uri: edit/main/doc-site/docs/
 
 use_directory_urls: true
 strict: false
+# Must match .github/workflows/github-pages.yml (upload-pages-artifact path)
+site_dir: _site
 
 theme:
   name: material


### PR DESCRIPTION
Set site_dir to _site so mkdocs build matches upload-pages-artifact and fixes tar failure when the default site/ directory was used.