### PR TITLE
Embed legacy HTML manuals in MkDocs Material and automate handbook nav

### DIFF
--- a/doc-site/README.md
+++ b/doc-site/README.md
@@ -10,4 +10,4 @@ python -m mkdocs build -f doc-site/mkdocs.yml
 
 For GitHub Pages, set `GHP_REPO_URL=https://github.com/OWNER/REPO` when running `prepare_docs.py` (the workflow does this automatically). Optional: `GHP_DEFAULT_BRANCH` (default `master`) controls the link to `doc/` in the hub page.
 
-The `prepare_docs.py` step copies `doc/*.html` into `docs/legacy-html/` so legacy manuals are embedded in the built site; run it before every `mkdocs build`.
+The **Legacy manuals** entries in `doc-site/mkdocs.yml` are rewritten by `prepare_docs.py` from every `doc/*.html`, so the side nav always lists all legacy pages after regeneration.

--- a/doc-site/docs/index.md
+++ b/doc-site/docs/index.md
@@ -1,9 +1,9 @@
 # Handbook overview
 
-LogAnalyzer is a PHP web front end for browsing syslog and related log data. This site collects **operational docs** (Docker, CI, fixtures) and links to the **legacy HTML manuals** shipped under [`doc/`](../doc/) in the repository.
+LogAnalyzer is a PHP web front end for browsing syslog and related log data. This site collects **operational docs** (Docker, CI, fixtures) and links to the **legacy HTML manuals** shipped under [`doc/`](https://github.com/rsyslog/loganalyzer/tree/master/doc) in the repository.
 
 - Start with [Docker & local development](docker.md) (`AGENTS.md` from the repo root).
 - [Third-party and bundled libraries](third-party.md) lists versions and update notes.
-- [Legacy HTML manuals (links)](legacy-html-manuals.md) points at `doc/*.html` on GitHub.
+- [Legacy HTML manuals (links)](legacy-html-manuals.md) lists the same manuals **inside this handbook** (Material layout); sources remain [`doc/*.html`](https://github.com/rsyslog/loganalyzer/tree/master/doc) on GitHub.
 
-The published site URL is configured in `doc-site/mkdocs.yml` (`site_url` / `repo_url`) — set these to match your GitHub Pages location.
+Handbook build: `doc-site/`; published at [https://rsyslog.github.io/loganalyzer/](https://rsyslog.github.io/loganalyzer/) (`site_url` in `mkdocs.yml`).

--- a/doc-site/docs/stylesheets/legacy-html.css
+++ b/doc-site/docs/stylesheets/legacy-html.css
@@ -1,0 +1,16 @@
+/* Legacy HTML manuals embedded in Markdown (Material wrapper) */
+.legacy-html-doc {
+  max-width: 100%;
+}
+
+.legacy-html-doc h2 {
+  margin-top: 1.75em;
+}
+
+.legacy-html-doc p {
+  margin: 0.75em 0;
+}
+
+.legacy-html-doc ul {
+  margin: 0.5em 0 1em 1.2em;
+}

--- a/doc-site/mkdocs.yml
+++ b/doc-site/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: LogAnalyzer handbook
 site_description: Adiscon LogAnalyzer — install, Docker dev, and bundled components
-site_url: https://example.github.io/loganalyzer/
-repo_url: https://github.com/example/loganalyzer
+site_url: https://rsyslog.github.io/loganalyzer/
+repo_url: https://github.com/rsyslog/loganalyzer
 repo_name: loganalyzer
-edit_uri: edit/main/doc-site/docs/
+edit_uri: edit/master/doc-site/docs/
 
 use_directory_urls: true
 strict: false
@@ -15,6 +15,9 @@ theme:
   features:
     - navigation.expand
     - content.code.copy
+
+extra_css:
+  - stylesheets/legacy-html.css
 
 markdown_extensions:
   - tables
@@ -28,10 +31,15 @@ nav:
   - Docker & CI (from AGENTS.md): docker.md
   - Legacy manuals (HTML):
     - Overview: legacy-html-manuals.md
-    - Documentation home: legacy-html/manual.html
-    - Basics: legacy-html/basics.html
-    - Installation: legacy-html/install.html
-    - Search syntax: legacy-html/searching.html
-    - Troubleshooting: legacy-html/troubleshoot.html
+    - Documentation home: legacy-html/manual.md
+    - Basics: legacy-html/basics.md
+    - Installation: legacy-html/install.md
+    - Search syntax: legacy-html/searching.md
+    - Troubleshooting: legacy-html/troubleshoot.md
+    - Build from repo: legacy-html/build_from_repo.md
+    - Free support: legacy-html/free_support.md
+    - Professional services: legacy-html/professional_services.md
+    - Text log files: legacy-html/textfiles.md
+    - Windows Event Log: legacy-html/windowsevent.md
   - Repository README: project-readme.md
   - Third-party components: third-party.md

--- a/doc-site/prepare_docs.py
+++ b/doc-site/prepare_docs.py
@@ -1,16 +1,177 @@
 #!/usr/bin/env python3
-"""Prepare doc-site/docs from repository Markdown; set GHP_REPO_URL for blob links."""
+"""Prepare doc-site/docs from repository Markdown; embed legacy HTML as MkDocs pages."""
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUT_DIR = Path(__file__).resolve().parent / "docs"
 LEGACY_SUBDIR = "legacy-html"
-REPO_URL = os.environ.get("GHP_REPO_URL", "https://github.com/example/loganalyzer").rstrip("/")
+REPO_URL = os.environ.get("GHP_REPO_URL", "https://github.com/rsyslog/loganalyzer").rstrip("/")
 DEFAULT_BRANCH = os.environ.get("GHP_DEFAULT_BRANCH", "master").strip() or "master"
+
+HREF_RE = re.compile(r"""(?is)\bhref\s*=\s*(["'])([^"']*)\1""")
+TITLE_RE = re.compile(r"""(?is)<title[^>]*>([^<]*)</title>""")
+BODY_RE = re.compile(r"""(?is)<body[^>]*>(.*?)</body>""")
+FIRST_H1_RE = re.compile(r"""(?is)^\s*<h1[^>]*>.*?</h1>\s*""")
+LEGACY_NAV_LINE = re.compile(r"^(\s*)-\s")
+
+# free_support.html links to a non-existent filename
+STEM_ALIASES = {"professional_support": "professional_services"}
+
+# Preferred left-nav order; any new doc/*.html not listed here is appended (sorted).
+LEGACY_NAV_ORDER = [
+    "manual",
+    "basics",
+    "install",
+    "searching",
+    "troubleshoot",
+    "build_from_repo",
+    "free_support",
+    "professional_services",
+    "textfiles",
+    "windowsevent",
+]
+
+# Left-nav labels (override stem-derived title)
+LEGACY_NAV_LABELS = {
+    "manual": "Documentation home",
+    "basics": "Basics",
+    "install": "Installation",
+    "searching": "Search syntax",
+    "troubleshoot": "Troubleshooting",
+    "build_from_repo": "Build from repo",
+    "free_support": "Free support",
+    "professional_services": "Professional services",
+    "textfiles": "Text log files",
+    "windowsevent": "Windows Event Log",
+}
+
+MKDOCS_PATH = Path(__file__).resolve().parent / "mkdocs.yml"
+LEGACY_NAV_HEADER = "  - Legacy manuals (HTML):"
+
+
+def _yaml_single_quoted(value: str) -> str:
+    """Single-quoted YAML scalar; double internal apostrophes per YAML 1.1/1.2."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _nav_item_indent(line: str) -> int | None:
+    m = LEGACY_NAV_LINE.match(line)
+    return len(m.group(1)) if m else None
+
+
+def _extract_title_and_body(html: str) -> tuple[str, str]:
+    tm = TITLE_RE.search(html)
+    title = (tm.group(1).strip() if tm else "Legacy manual").replace("\n", " ")
+    bm = BODY_RE.search(html)
+    body = bm.group(1).strip() if bm else html
+    body = FIRST_H1_RE.sub("", body, count=1)
+    return title, body
+
+
+def _rewrite_hrefs(fragment: str, stems: set[str]) -> str:
+    lower_to_canon = {s.lower(): s for s in stems}
+
+    def repl(m: re.Match[str]) -> str:
+        quote, url = m.group(1), m.group(2)
+        lower = url.lower()
+        if lower.startswith(("http://", "https://", "mailto:", "#", "//")):
+            return m.group(0)
+        base, _, frag = url.partition("#")
+        frag_q = f"#{frag}" if frag else ""
+        if not base:
+            return m.group(0)
+
+        stem: str | None = None
+        if base.lower().endswith(".html"):
+            stem = base.rsplit(".", 1)[0]
+        elif "." not in base:
+            stem = base
+
+        if stem is None:
+            return m.group(0)
+
+        stem_l = stem.lower()
+        stem_l = STEM_ALIASES.get(stem_l, stem_l)
+        canon = lower_to_canon.get(stem_l)
+        if canon:
+            return f"href={quote}../{canon}/{frag_q}{quote}"
+        if base.lower().endswith(".html"):
+            return f"href={quote}../{stem}/{frag_q}{quote}"
+        return m.group(0)
+
+    return HREF_RE.sub(repl, fragment)
+
+
+def _ordered_legacy_stems(stems: set[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for s in LEGACY_NAV_ORDER:
+        if s in stems:
+            out.append(s)
+            seen.add(s)
+    out.extend(sorted(stems - seen))
+    return out
+
+
+def _format_legacy_nav_lines(stems_ordered: list[str]) -> list[str]:
+    lines = [
+        LEGACY_NAV_HEADER,
+        "    - Overview: legacy-html-manuals.md",
+    ]
+    for stem in stems_ordered:
+        label = LEGACY_NAV_LABELS.get(stem, stem.replace("_", " ").title())
+        lines.append(f"    - {label}: legacy-html/{stem}.md")
+    return lines
+
+
+def _patch_mkdocs_legacy_nav(stems_ordered: list[str]) -> None:
+    text = MKDOCS_PATH.read_text(encoding="utf-8", errors="replace")
+    file_lines = text.splitlines()
+    start_i: int | None = None
+    for i, line in enumerate(file_lines):
+        if line == LEGACY_NAV_HEADER:
+            start_i = i
+            break
+    if start_i is None:
+        raise SystemExit(f"{MKDOCS_PATH}: missing {LEGACY_NAV_HEADER!r} nav section")
+    header_indent = _nav_item_indent(file_lines[start_i])
+    if header_indent is None:
+        raise SystemExit(f"{MKDOCS_PATH}: legacy nav header is not a valid list item")
+    end_i = start_i + 1
+    while end_i < len(file_lines):
+        line = file_lines[end_i]
+        if not line.strip():
+            break
+        child_indent = _nav_item_indent(line)
+        if child_indent is None or child_indent <= header_indent:
+            break
+        end_i += 1
+    new_file_lines = (
+        file_lines[:start_i] + _format_legacy_nav_lines(stems_ordered) + file_lines[end_i:]
+    )
+    MKDOCS_PATH.write_text("\n".join(new_file_lines) + "\n", encoding="utf-8", newline="\n")
+    print(f"Updated {MKDOCS_PATH.name} legacy nav ({len(stems_ordered)} manual page(s))")
+
+
+def _write_legacy_markdown(
+    out_path: Path,
+    title: str,
+    body_html: str,
+) -> None:
+    md = (
+        "---\n"
+        f"title: {_yaml_single_quoted(title)}\n"
+        "---\n\n"
+        '<div class="legacy-html-doc">\n\n'
+        f"{body_html}\n\n"
+        "</div>\n"
+    )
+    out_path.write_text(md, encoding="utf-8", newline="\n")
 
 
 def main() -> int:
@@ -31,27 +192,40 @@ def main() -> int:
             shutil.rmtree(legacy_out)
         legacy_out.mkdir(parents=True, exist_ok=True)
         html_files = sorted(manuals.glob("*.html"))
+        stems = {f.stem for f in html_files}
+
         for src in html_files:
-            shutil.copyfile(src, legacy_out / src.name)
-            print(f"Copied {src.name} -> {legacy_out / src.name}")
+            raw = src.read_text(encoding="utf-8", errors="replace")
+            doc_title, body = _extract_title_and_body(raw)
+            body = _rewrite_hrefs(body, stems)
+            md_name = src.with_suffix(".md").name
+            _write_legacy_markdown(legacy_out / md_name, doc_title, body)
+            print(f"Wrote {legacy_out / md_name} <- {src.name}")
 
         blob_base = f"{REPO_URL}/blob/{DEFAULT_BRANCH}/doc"
         rel_prefix = f"{LEGACY_SUBDIR}/"
 
+        ordered = _ordered_legacy_stems(stems)
+        stem_to_html = {f.stem: f.name for f in html_files}
         lines = [
             "# Legacy HTML manuals",
             "",
             "These pages are **legacy HTML 4** manuals from the upstream tree. They are "
-            "**included in this handbook** so you can read them without leaving the site. "
-            "For Docker, CI, and contributor notes, use the other sections in the left nav.",
+            "**included in this handbook** (Material theme and navigation) so you can read them "
+            "without leaving the site. For Docker, CI, and contributor notes, use the other "
+            "sections in the left nav.",
+            "",
+            f"Every file under [`doc/`]({blob_base}/) with a `*.html` extension is listed below "
+            f"**({len(ordered)} manuals)**; the same pages appear under "
+            "**Legacy manuals (HTML)** in the left sidebar (same order and titles).",
             "",
             "## Pages (in-site)",
             "",
         ]
-        for f in html_files:
-            name = f.name
-            title = name.replace(".html", "").replace("_", " ")
-            lines.append(f"- [{title}]({rel_prefix}{name}) (`{name}`)")
+        for stem in ordered:
+            label = LEGACY_NAV_LABELS.get(stem, stem.replace("_", " ").title())
+            html_name = stem_to_html[stem]
+            lines.append(f"- [{label}]({rel_prefix}{stem}.md) (`{html_name}`)")
         lines.extend(
             [
                 "",
@@ -67,6 +241,7 @@ def main() -> int:
             newline="\n",
         )
         print(f"Wrote {OUT_DIR / 'legacy-html-manuals.md'}")
+        _patch_mkdocs_legacy_nav(_ordered_legacy_stems(stems))
     return 0
 
 


### PR DESCRIPTION
Generate each `doc/*.html` as `docs/legacy-html/*.md` with embedded body HTML, href rewrites for directory URLs, and `extra_css` for legacy prose. `prepare_docs.py` now refreshes the Legacy manuals block in `mkdocs.yml` from every `doc/*.html`, builds the overview hub with matching titles/order, and defaults GitHub blob links to rsyslog/loganalyzer. Point `site_url`, `repo_url`, `edit_uri`, README, and `index.md` at the real GitHub Pages repo and published URL.

Validation: `python doc-site/prepare_docs.py` and `python -m mkdocs build -f doc-site/mkdocs.yml` (local).

Note: also commit `doc-site/docs/stylesheets/legacy-html.css` (currently untracked); skip `.phpunit.result.cache` / `diff.log`.