### PR TITLE
Fix CVE-2023-34600 admin SQLi and harden quoted SQL escaping

### DIFF
--- a/doc-site/docs/docker.md
+++ b/doc-site/docs/docker.md
@@ -1,0 +1,57 @@
+# LogAnalyzer agent / contributor notes
+
+## Docker development
+
+From the repository root:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+**Clean rebuild** (drops MySQL data and re-seeds; `src/config.php` is regenerated on web container start):
+
+- Linux/macOS/Git Bash: `sh docker/rebuild-dev.sh`
+- Windows (cmd): `docker\rebuild-dev.bat`
+
+**E2E clean run** (fresh E2E DB + Playwright):
+
+- `sh docker/rebuild-e2e.sh` or `docker\rebuild-e2e.bat`
+
+- **Web UI:** http://localhost:8080/
+- **MySQL:** `localhost:3306`, database `loganalyzer`, user `loganalyzer` / `loganalyzer`, root password `loganalyzer_root`
+- **Admin login:** `admin` / `pass` (seeded once per fresh MySQL volume)
+- **Sample logs** are mounted read-only at `/samplelogs` from [tests/fixtures/samplelogs](https://github.com/rsyslog/loganalyzer/tree/master/tests/fixtures/samplelogs). The default seeded source reads `sampledata_syslog.log`.
+
+Reset the database and config: `docker compose -f docker/docker-compose.yml down -v` then `up --build` again.
+
+### Environment variables (web container)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LOGANALYZER_DB_HOST` | `db` | MySQL host |
+| `LOGANALYZER_DB_PORT` | `3306` | MySQL port |
+| `LOGANALYZER_DB_NAME` | `loganalyzer` | Database name |
+| `LOGANALYZER_DB_USER` | `loganalyzer` | App DB user |
+| `LOGANALYZER_DB_PASSWORD` | `loganalyzer` | App DB password |
+| `MYSQL_ROOT_PASSWORD` | `loganalyzer_root` | Root (used by seed script only) |
+| `LOGANALYZER_TABLE_PREFIX` | `logcon_` | Table prefix |
+| `LOGANALYZER_ADMIN_USER` | `admin` | First admin username |
+| `LOGANALYZER_ADMIN_PASSWORD` | `pass` | First admin password |
+| `LOGANALYZER_LOGIN_REQUIRED` | `0` | Set `1` to force login on all pages |
+| `LOGANALYZER_SAMPLE_LOG` | `/samplelogs/sampledata_syslog.log` | First seeded disk source (syslog) |
+| `LOGANALYZER_SAMPLE_EVENTREPORTER` | `/samplelogs/EventReporter.log` | Second seeded disk source (Windows EventReporter / EvntSLog) |
+| `LOGANALYZER_SKIP_SEED` | unset | Set `1` to skip MySQL seed |
+| `LOGANALYZER_OVERWRITE_CONFIG` | `1` | Overwrite `src/config.php` on each start in dev |
+
+## PHPUnit
+
+```bash
+composer install
+composer test
+```
+
+MySQL-dependent integration tests are skipped unless `LOGANALYZER_INTEGRATION=1` and DB env vars match Docker defaults or your own host.
+
+## E2E (Playwright)
+
+See [e2e/README.md](https://github.com/rsyslog/loganalyzer/blob/master/e2e/README.md) and `docker/docker-compose.e2e.yml`.

--- a/doc-site/docs/legacy-html-manuals.md
+++ b/doc-site/docs/legacy-html-manuals.md
@@ -1,0 +1,23 @@
+# Legacy HTML manuals
+
+These pages are **legacy HTML 4** manuals from the upstream tree. They are **included in this handbook** (Material theme and navigation) so you can read them without leaving the site. For Docker, CI, and contributor notes, use the other sections in the left nav.
+
+Every file under [`doc/`](https://github.com/rsyslog/loganalyzer/blob/master/doc/) with a `*.html` extension is listed below **(10 manuals)**; the same pages appear under **Legacy manuals (HTML)** in the left sidebar (same order and titles).
+
+## Pages (in-site)
+
+- [Documentation home](legacy-html/manual.md) (`manual.html`)
+- [Basics](legacy-html/basics.md) (`basics.html`)
+- [Installation](legacy-html/install.md) (`install.html`)
+- [Search syntax](legacy-html/searching.md) (`searching.html`)
+- [Troubleshooting](legacy-html/troubleshoot.md) (`troubleshoot.html`)
+- [Build from repo](legacy-html/build_from_repo.md) (`build_from_repo.html`)
+- [Free support](legacy-html/free_support.md) (`free_support.html`)
+- [Professional services](legacy-html/professional_services.md) (`professional_services.html`)
+- [Text log files](legacy-html/textfiles.md) (`textfiles.html`)
+- [Windows Event Log](legacy-html/windowsevent.md) (`windowsevent.html`)
+
+## Source in the repository
+
+Original files live under [`doc/`](https://github.com/rsyslog/loganalyzer/blob/master/doc/) on branch `master`.
+

--- a/doc-site/docs/project-readme.md
+++ b/doc-site/docs/project-readme.md
@@ -1,0 +1,54 @@
+Developer-oriented setup (Docker, CI, Playwright): see [AGENTS.md](https://github.com/rsyslog/loganalyzer/blob/master/AGENTS.md).
+
+# loganalyzer
+
+![loganalizer_example](https://user-images.githubusercontent.com/8426197/209875963-b7438f3b-9052-4e8f-9f22-05794e1e54a5.png)
+Adiscon LogAnalyzer, a web frontend to log data from the same folks that created rsyslog
+
+# todo
+ - export: add checkbox to export full filtered history (now exports only current page)
+ - export: place ts into export filename (range from-to)
+ - BUG: "Suppress duplicated messages" doesn't work
+ - filter: allow to specify AFTER:n BEFORE:n (if possible/fast to implement) <- include records before and after match
+ - export: configure columns for file export (allow to remove unnecessary columns) <- exclude list of columns
+ - BUG: sometimes spinner on index page is drawn in the middle of page irrespective of it's size, but should be drawn in the middle of screen
+ 
+# changes 230121
+ - datelastx - keep for backward compatibility (for saved searches); add datelastxx
+
+# changes 230114
+ - fix bug: WHERE ( message LIKE '%LTE%unreachable%' ) give no result on filter page, yet works for charts, i.e. input = msg:LTE%unreachable (todo# in chart records have wrong date today merged with yesterday)
+ - cfg[EventEmptySearchDefaultFilter] - config to use in case filter is empty (first load)
+ - cfg[ExportUseTodayYesterday] - allow to export date in case today/yesterday enabled 
+ - CFG[Default_AUTORELOAD_ID] - control default autoreload mode
+ - cfg[SESSION_MAXIMIZED] - control maximized mode
+ - filter: support "limit:int" tag - disable paging and query less than configured for page (LogStreamDB->_SQLcustomLimitHaltSearchAfter)
+ 
+![limit_10](https://user-images.githubusercontent.com/8426197/212502393-d05d0cb9-4baf-4008-838b-ce078b6eeb8b.png)
+
+ - filter: datelastx - handle as float number
+ - export: allow to EXPORT_PLAIN text format	
+ - custom bug fixes
+ - rename SYSLOG_TRACE to CUSTOM_TRACE;
+ - translations: {LN_CHART_ORDERBY, LN_CHART_FILTER, LN_GEN_EMPTYSRCHFILTR, LN_GEN_EXPORT_PLAIN, LN_GEN_EXPORT_USETODAY, LN_GEN_SESSION_MAX}
+ 
+# changes
+ - fix bug: chart double adding same key into search
+ - allow to configure ORDER BY clause
+ - add custom filter to chart value redirection link if such exists
+ 
+![chart_custom](https://user-images.githubusercontent.com/8426197/210448944-9a67c91c-1ca7-4f00-99ac-a5eebd566927.png)
+
+ - filter: support number ranges, i.e. severity:3-6 -> where severity in (3,4,5,6)
+ - filter: support quoted filters, i.e. syslogtag:-="dhcp,info",-="wireless,info",-"system%,account" ->  where (syslogtag <> 'dhcp,info' AND syslogtag <> 'wireless,info' AND syslogtag NOT LIKE '%system%,account%' )
+ - filter: support TRACE severity level; 
+ - gui: add loglevel style colors and change color for full line; 
+ - filter: change datelastx behaviour - use number as hours indicator, i.e. datelastx:3 is 3 hours limit
+ 
+ #obsolete
+ - filter: allow to OR msg, i.e. key1 &key2 |key3;
+ - filter: date{from,to} - allow to use today/yesterday + short time, i.e. today 1h same as 1h, yesterday 2h, since/after/before/etc.
+ - "Maximize view" - reloads page and resets search filter, hide toolbars with js instead
+ - changing "Autoreload" does the same as "Max. view"
+ - allow to manually configure log levels (severity) instead of using constants
+ - cfg[ExportCSVDelimiter,ExportCSVQuoteValues] - allow to EXPORT_PLAIN text format

--- a/src/admin/charts.php
+++ b/src/admin/charts.php
@@ -99,8 +99,8 @@ if ( isset($_GET['miniop']) )
 		if ( $_GET['miniop'] == "setenabled" ) 
 		{
 			//PreInit these values 
-			$content['CHARTID'] = intval(DB_RemoveBadChars($_GET['id']));
-			$iNewVal = intval(DB_RemoveBadChars($_GET['newval']));
+			$content['CHARTID'] = intval($_GET['id']);
+			$iNewVal = intval($_GET['newval']);
 
 			// Perform SQL Query!
 			$sqlquery = "SELECT * " . 
@@ -188,10 +188,10 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['CHARTID'] = DB_RemoveBadChars($_GET['id']);
+			$content['CHARTID'] = intval($_GET['id']);
 
 			// Check if exists
-			if ( is_numeric($content['CHARTID']) && isset($content['Charts'][ $content['CHARTID'] ]) )
+			if ( isset($content['Charts'][ $content['CHARTID'] ]) )
 			{
 				// Get Source reference
 				$myChart = $content['Charts'][ $content['CHARTID'] ];
@@ -269,7 +269,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['CHARTID'] = DB_RemoveBadChars($_GET['id']);
+			$content['CHARTID'] = intval($_GET['id']);
 
 			// Get UserInfo
 			$result = DB_Query("SELECT DisplayName FROM " . DB_CHARTS . " WHERE ID = " . $content['CHARTID'] ); 
@@ -312,15 +312,15 @@ if ( isset($_GET['op']) )
 if ( isset($_POST['op']) )
 {
 	// Read parameters first!
-	if ( isset($_POST['id']) ) { $content['CHARTID'] = intval(DB_RemoveBadChars($_POST['id'])); } else {$content['CHARTID'] = -1; }
+	if ( isset($_POST['id']) && is_scalar($_POST['id']) ) { $content['CHARTID'] = intval($_POST['id']); } else {$content['CHARTID'] = -1; }
 	if ( isset($_POST['Name']) ) { $content['Name'] = DB_RemoveBadChars($_POST['Name']); } else {$content['Name'] = ""; }
-	if ( isset($_POST['chart_enabled']) ) { $content['chart_enabled'] = intval(DB_RemoveBadChars($_POST['chart_enabled'])); } else {$content['chart_enabled'] = 0; }
-	if ( isset($_POST['chart_type']) ) { $content['chart_type'] = intval(DB_RemoveBadChars($_POST['chart_type'])); }
-	if ( isset($_POST['chart_width']) ) { $content['chart_width'] = intval(DB_RemoveBadChars($_POST['chart_width'])); } else {$content['chart_width'] = 400; }
+	if ( isset($_POST['chart_enabled']) ) { $content['chart_enabled'] = intval($_POST['chart_enabled']); } else {$content['chart_enabled'] = 0; }
+	if ( isset($_POST['chart_type']) ) { $content['chart_type'] = intval($_POST['chart_type']); }
+	if ( isset($_POST['chart_width']) ) { $content['chart_width'] = intval($_POST['chart_width']); } else {$content['chart_width'] = 400; }
 	if ( isset($_POST['chart_field']) ) { $content['chart_field'] = DB_RemoveBadChars($_POST['chart_field']); }
 	if ( isset($_POST['chart_orderby']) ) { $content['chart_orderby'] = DB_RemoveBadChars($_POST['chart_orderby']); }
-	if ( isset($_POST['maxrecords']) ) { $content['maxrecords'] = intval(DB_RemoveBadChars($_POST['maxrecords'])); }
-	if ( isset($_POST['showpercent']) ) { $content['showpercent'] = intval(DB_RemoveBadChars($_POST['showpercent'])); } else {$content['showpercent'] = 0; }
+	if ( isset($_POST['maxrecords']) ) { $content['maxrecords'] = intval($_POST['maxrecords']); }
+	if ( isset($_POST['showpercent']) ) { $content['showpercent'] = intval($_POST['showpercent']); } else {$content['showpercent'] = 0; }
 	if ( isset($_POST['chart_defaultfilter']) ) { $content['chart_defaultfilter'] = DB_RemoveBadChars($_POST['chart_defaultfilter']); }
 	
 	// User & Group handeled specially

--- a/src/admin/dbmappings.php
+++ b/src/admin/dbmappings.php
@@ -85,10 +85,9 @@ if ( isset($_GET['op']) )
 		$content['DBMP'] = $dbmapping;
 
 		// View must be loaded as well already!
-		if ( isset($_GET['dbmpid']) && isset($content['DBMP'][$_GET['dbmpid']]) )
+		if ( isset($_GET['dbmpid']) )
 		{
-			//PreInit these values 
-			$content['DBMPID'] = DB_RemoveBadChars($_GET['dbmpid']);
+			$content['DBMPID'] = intval($_GET['dbmpid']);
 			if ( isset($content['DBMP'][ $content['DBMPID'] ]) )
 			{
 				//Set the FormAdd URL
@@ -117,7 +116,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['dbmpid']) )
 		{
 			//PreInit these values 
-			$content['DBMPID'] = DB_RemoveBadChars($_GET['dbmpid']);
+			$content['DBMPID'] = intval($_GET['dbmpid']);
 
 			// Get UserInfo
 			$result = DB_Query("SELECT DisplayName FROM " . DB_MAPPINGS . " WHERE ID = " . $content['DBMPID'] ); 
@@ -248,7 +247,7 @@ if ( isset($content['ISEDITORNEWDBMP']) && $content['ISEDITORNEWDBMP'] )
 // --- Process POST Form Data
 if ( isset($_POST['op']) )
 {
-	if ( isset ($_POST['dbmpid']) ) { $content['DBMPID'] = DB_RemoveBadChars($_POST['dbmpid']); } else {$content['DBMPID'] = ""; }
+	if ( isset ($_POST['dbmpid']) && is_scalar($_POST['dbmpid']) ) { $content['DBMPID'] = intval($_POST['dbmpid']); } else {$content['DBMPID'] = 0; }
 	if ( isset ($_POST['DisplayName']) ) { $content['DisplayName'] = DB_StripSlahes($_POST['DisplayName']); } else {$content['DisplayName'] = ""; }
 
 	// --- Check mandotary values

--- a/src/admin/fields.php
+++ b/src/admin/fields.php
@@ -193,8 +193,8 @@ if ( isset($_POST['op']) )
 	if ( isset($_POST['FieldAlign']) && isset($content['ALIGMENTS'][$_POST['FieldAlign']]) ) { $content['FieldAlign'] = $_POST['FieldAlign']; } else {$content['FieldAlign'] = ALIGN_CENTER; }
 
 	// number fields
-	if ( isset($_POST['DefaultWidth']) ) { $content['DefaultWidth'] = intval(DB_RemoveBadChars($_POST['DefaultWidth'])); } else {$content['DefaultWidth'] = 50; }
-//	NOT USED YET if ( isset ($_POST['Trunscate']) ) { $content['Trunscate'] = intval(DB_RemoveBadChars($_POST['Trunscate'])); } else {$content['Trunscate'] = 30; }
+	if ( isset($_POST['DefaultWidth']) ) { $content['DefaultWidth'] = intval($_POST['DefaultWidth']); } else {$content['DefaultWidth'] = 50; }
+//	NOT USED YET if ( isset ($_POST['Trunscate']) ) { $content['Trunscate'] = intval($_POST['Trunscate']); } else {$content['Trunscate'] = 30; }
 	CreateFieldTypesList(0);
 	if ( isset($_POST['NewFieldType']) && isset($content['FILTERTYPES'][$_POST['NewFieldType']]) ) { $content['FieldType'] = intval($_POST['NewFieldType']); } else if ( isset($_POST['FieldType']) && isset($content['FILTERTYPES'][$_POST['FieldType']]) ) { $content['FieldType'] = intval($_POST['FieldType']); } else { $content['FieldType'] = FILTER_TYPE_STRING; }
 

--- a/src/admin/groups.php
+++ b/src/admin/groups.php
@@ -91,7 +91,7 @@ if ( isset($_GET['op']) )
 	else if ($_GET['op'] == "adduser" && isset($_GET['id']) ) 
 	{
 		//PreInit these values 
-		$content['GROUPID'] = intval( DB_RemoveBadChars($_GET['id']) );
+		$content['GROUPID'] = intval($_GET['id']);
 
 		// Set Mode to add
 		$content['ISADDUSER'] = "true";
@@ -170,7 +170,7 @@ if ( isset($_GET['op']) )
 	else if ($_GET['op'] == "removeuser" && isset($_GET['id']) ) 
 	{
 		//PreInit these values 
-		$content['GROUPID'] = intval( DB_RemoveBadChars($_GET['id']) );
+		$content['GROUPID'] = intval($_GET['id']);
 
 		// Set Mode to add
 		$content['ISREMOVEUSER'] = "true";
@@ -230,7 +230,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['GROUPID'] = DB_RemoveBadChars($_GET['id']);
+			$content['GROUPID'] = intval($_GET['id']);
 
 			$sqlquery = "SELECT * " . 
 						" FROM " . DB_GROUPS . 
@@ -261,7 +261,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['GROUPID'] = DB_RemoveBadChars($_GET['id']);
+			$content['GROUPID'] = intval($_GET['id']);
 
 			// Get GroupInfo
 			$result = DB_Query("SELECT groupname FROM " . DB_GROUPS . " WHERE ID = " . $content['GROUPID'] ); 
@@ -305,7 +305,7 @@ if ( isset($_GET['op']) )
 
 if ( isset($_POST['op']) )
 {
-	if ( isset ($_POST['id']) ) { $content['GROUPID'] = intval( DB_RemoveBadChars($_POST['id']) ); } else {$content['GROUPID'] = ""; }
+	if ( isset ($_POST['id']) && is_scalar($_POST['id']) ) { $content['GROUPID'] = intval($_POST['id']); } else {$content['GROUPID'] = 0; }
 	if ( isset ($_POST['groupname']) ) { $content['groupname'] = DB_RemoveBadChars($_POST['groupname']); } else {$content['groupname'] = ""; }
 	if ( isset ($_POST['groupdescription']) ) { $content['groupdescription'] = DB_RemoveBadChars($_POST['groupdescription']); } else {$content['groupdescription'] = ""; }
 
@@ -368,7 +368,7 @@ if ( isset($_POST['op']) )
 			if ( isset($_POST['userid']) ) 
 			{ 
 				// Copy UserID
-				$content['USERID'] = intval( DB_RemoveBadChars($_POST['userid']) ); 
+				$content['USERID'] = intval($_POST['userid']); 
 
 				$result = DB_Query("SELECT username FROM " . DB_USERS . " WHERE id = " . $content['USERID']); 
 				$myrow = DB_GetSingleRow($result, true);
@@ -401,7 +401,7 @@ if ( isset($_POST['op']) )
 			if ( isset($_POST['userid']) ) 
 			{ 
 				// Copy UserID
-				$content['USERID'] = intval( DB_RemoveBadChars($_POST['userid']) ); 
+				$content['USERID'] = intval($_POST['userid']); 
 
 				$result = DB_Query("SELECT username FROM " . DB_USERS . " WHERE id = " . $content['USERID']); 
 				$myrow = DB_GetSingleRow($result, true);

--- a/src/admin/reports.php
+++ b/src/admin/reports.php
@@ -440,7 +440,7 @@ if ( isset($_GET['op']) )
 				$content['REPORTS_DETAILSFOR'] = GetAndReplaceLangStr( $content['LN_REPORTS_DETAILSFOR'], $content['ReportID'] ); 
 
 				// Now Get data from saved report!
-				$content['SavedReportID'] = DB_RemoveBadChars($_GET['savedreportid']);
+				$content['SavedReportID'] = intval($_GET['savedreportid']);
 
 				if ( isset($myReport['SAVEDREPORTS'][$content['SavedReportID']]) ) 
 				{
@@ -525,7 +525,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['savedreportid']) )
 		{
 			//PreInit these values 
-			$content['SavedReportID'] = DB_RemoveBadChars($_GET['savedreportid']);
+			$content['SavedReportID'] = intval($_GET['savedreportid']);
 
 			// Get GroupInfo
 			$result = DB_Query("SELECT customTitle FROM " . DB_SAVEDREPORTS . " WHERE ID = " . $content['SavedReportID'] ); 
@@ -1019,7 +1019,7 @@ if ( isset($_POST['op']) )
 		$myReport = $content['REPORTS'][ $content['ReportID'] ];
 
 		// Get SavedReportID!
-		if ( isset($_POST['savedreportid']) ) { $content['SavedReportID'] = DB_RemoveBadChars($_POST['savedreportid']); } else {$content['SavedReportID'] = ""; }
+		if ( isset($_POST['savedreportid']) && is_scalar($_POST['savedreportid']) ) { $content['SavedReportID'] = intval($_POST['savedreportid']); } else {$content['SavedReportID'] = 0; }
 
 		// Read parameters
 		if ( isset($_POST['SourceID']) ) { $content['SourceID'] = DB_RemoveBadChars($_POST['SourceID']); }

--- a/src/admin/searches.php
+++ b/src/admin/searches.php
@@ -128,7 +128,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SEARCHID'] = strip_tags(DB_RemoveBadChars($_GET['id']));
+			$content['SEARCHID'] = intval($_GET['id']);
 
 			$sqlquery = "SELECT * " . 
 						" FROM " . DB_SEARCHES . 
@@ -191,7 +191,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SEARCHID'] = strip_tags(DB_RemoveBadChars($_GET['id']));
+			$content['SEARCHID'] = intval($_GET['id']);
 
 			// Get UserInfo
 			$result = DB_Query("SELECT DisplayName FROM " . DB_SEARCHES . " WHERE ID = " . $content['SEARCHID'] ); 
@@ -233,7 +233,7 @@ if ( isset($_GET['op']) )
 
 if ( isset($_POST['op']) )
 {
-	if ( isset ($_POST['id']) ) { $content['SEARCHID'] = intval(DB_RemoveBadChars($_POST['id'])); } else {$content['SEARCHID'] = -1; }
+	if ( isset ($_POST['id']) && is_scalar($_POST['id']) ) { $content['SEARCHID'] = intval($_POST['id']); } else {$content['SEARCHID'] = -1; }
 	if ( isset ($_POST['DisplayName']) ) { $content['DisplayName'] = DB_RemoveBadChars($_POST['DisplayName']); } else {$content['DisplayName'] = ""; }
 	if ( isset ($_POST['SearchQuery']) ) { $content['SearchQuery'] = DB_RemoveBadChars($_POST['SearchQuery']); } else {$content['SearchQuery'] = ""; }
 

--- a/src/admin/sources.php
+++ b/src/admin/sources.php
@@ -177,10 +177,10 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SOURCEID'] = DB_RemoveBadChars($_GET['id']);
+			$content['SOURCEID'] = intval($_GET['id']);
 
 			// Check if exists
-			if ( is_numeric($content['SOURCEID']) && isset($content['Sources'][ $content['SOURCEID'] ]) )
+			if ( isset($content['Sources'][ $content['SOURCEID'] ]) )
 			{
 				// Get Source reference
 				$mysource = $content['Sources'][ $content['SOURCEID'] ];
@@ -296,7 +296,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SOURCEID'] = DB_RemoveBadChars($_GET['id']);
+			$content['SOURCEID'] = intval($_GET['id']);
 
 			// Get SourceInfo
 			$result = DB_Query("SELECT Name FROM " . DB_SOURCES . " WHERE ID = " . $content['SOURCEID'] ); 
@@ -339,7 +339,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SOURCEID'] = DB_RemoveBadChars($_GET['id']);
+			$content['SOURCEID'] = intval($_GET['id']);
 		}
 
 		// Check If source is available
@@ -473,7 +473,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['SOURCEID'] = DB_RemoveBadChars($_GET['id']);
+			$content['SOURCEID'] = intval($_GET['id']);
 		}
 
 		// Check If source is available
@@ -563,13 +563,13 @@ if ( isset($_GET['op']) )
 if ( isset($_POST['op']) )
 {
 	// Read parameters first!
-	if ( isset($_POST['id']) ) { $content['SOURCEID'] = intval(DB_RemoveBadChars($_POST['id'])); } else {$content['SOURCEID'] = -1; }
+	if ( isset($_POST['id']) && is_scalar($_POST['id']) ) { $content['SOURCEID'] = intval($_POST['id']); } else {$content['SOURCEID'] = -1; }
 	if ( isset($_POST['Name']) ) { $content['Name'] = DB_RemoveBadChars($_POST['Name']); } else {$content['Name'] = ""; }
 	if ( isset($_POST['Description']) ) { $content['Description'] = DB_RemoveBadChars($_POST['Description']); } else {$content['Description'] = ""; }
 	if ( isset($_POST['SourceType']) ) { $content['SourceType'] = DB_RemoveBadChars($_POST['SourceType']); }
 	if ( isset($_POST['MsgParserList']) ) { $content['MsgParserList'] = DB_RemoveBadChars($_POST['MsgParserList']); }
-	if ( isset($_POST['MsgNormalize']) ) { $content['MsgNormalize'] = intval(DB_RemoveBadChars($_POST['MsgNormalize'])); } else {$content['MsgNormalize'] = 0; }
-	if ( isset($_POST['MsgSkipUnparseable']) ) { $content['MsgSkipUnparseable'] = intval(DB_RemoveBadChars($_POST['MsgSkipUnparseable'])); } else {$content['MsgSkipUnparseable'] = 0; }
+	if ( isset($_POST['MsgNormalize']) ) { $content['MsgNormalize'] = intval($_POST['MsgNormalize']); } else {$content['MsgNormalize'] = 0; }
+	if ( isset($_POST['MsgSkipUnparseable']) ) { $content['MsgSkipUnparseable'] = intval($_POST['MsgSkipUnparseable']); } else {$content['MsgSkipUnparseable'] = 0; }
 	if ( isset($_POST['SourceViewID']) ) { $content['SourceViewID'] = DB_RemoveBadChars($_POST['SourceViewID']); }
 	if ( isset($_POST['defaultfilter']) ) { $content['defaultfilter'] = DB_RemoveBadChars($_POST['defaultfilter']); }
 

--- a/src/admin/users.php
+++ b/src/admin/users.php
@@ -88,8 +88,8 @@ if ( isset($_GET['miniop']) )
 		if ( $_GET['miniop'] == "setisadmin" ) 
 		{
 			//PreInit these values 
-			$content['USERID'] = intval(DB_RemoveBadChars($_GET['id']));
-			$iNewVal = intval(DB_RemoveBadChars($_GET['newval']));
+			$content['USERID'] = is_scalar($_GET['id']) ? intval($_GET['id']) : 0;
+			$iNewVal = is_scalar($_GET['newval']) ? intval($_GET['newval']) : 0;
 
 			// --- handle special case
 			if ( $content['USERID'] == $content['SESSION_USERID'] && (!isset($_GET['verify']) || $_GET['verify'] != "yes") && $iNewVal == 0)
@@ -122,8 +122,8 @@ if ( isset($_GET['miniop']) )
 		else if ( $_GET['miniop'] == "setisreadonly" ) 
 		{
 			//PreInit these values 
-			$content['USERID'] = intval(DB_RemoveBadChars($_GET['id']));
-			$iNewVal = intval(DB_RemoveBadChars($_GET['newval']));
+			$content['USERID'] = is_scalar($_GET['id']) ? intval($_GET['id']) : 0;
+			$iNewVal = is_scalar($_GET['newval']) ? intval($_GET['newval']) : 0;
 
 			// --- handle special case
 			if ( $content['USERID'] == $content['SESSION_USERID'] && (!isset($_GET['verify']) || $_GET['verify'] != "yes") && $iNewVal == 1)
@@ -186,7 +186,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['USERID'] = DB_RemoveBadChars($_GET['id']);
+			$content['USERID'] = is_scalar($_GET['id']) ? intval($_GET['id']) : 0;
 
 			$sqlquery = "SELECT * " . 
 						" FROM " . DB_USERS . 
@@ -228,7 +228,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['USERID'] = DB_RemoveBadChars($_GET['id']);
+			$content['USERID'] = is_scalar($_GET['id']) ? intval($_GET['id']) : 0;
 
 			if ( !isset($_SESSION['SESSION_USERNAME']) )
 			{
@@ -285,7 +285,7 @@ if ( isset($_GET['op']) )
 
 if ( isset($_POST['op']) )
 {
-	if ( isset ($_POST['id']) ) { $content['USERID'] = DB_RemoveBadChars($_POST['id']); } else {$content['USERID'] = ""; }
+	if ( isset ($_POST['id']) && is_scalar($_POST['id']) ) { $content['USERID'] = intval($_POST['id']); } else {$content['USERID'] = 0; }
 	if ( isset ($_POST['username']) ) { $content['USERNAME'] = DB_RemoveBadChars($_POST['username']); } else {$content['USERNAME'] = ""; }
 	if ( isset ($_POST['password1']) ) { $content['PASSWORD1'] = DB_RemoveBadChars($_POST['password1']); } else {$content['PASSWORD1'] = ""; }
 	if ( isset ($_POST['password2']) ) { $content['PASSWORD2'] = DB_RemoveBadChars($_POST['password2']); } else {$content['PASSWORD2'] = ""; }

--- a/src/admin/views.php
+++ b/src/admin/views.php
@@ -135,10 +135,9 @@ if ( isset($_GET['op']) )
 		$content['VIEWS'] = $content['Views'];
 
 		// View must be loaded as well already!
-		if ( isset($_GET['id']) && isset($content['VIEWS'][$_GET['id']]) )
+		if ( isset($_GET['id']) )
 		{
-			//PreInit these values 
-			$content['VIEWID'] = DB_RemoveBadChars($_GET['id']);
+			$content['VIEWID'] = intval($_GET['id']);
 			if ( isset($content['VIEWS'][ $content['VIEWID'] ]) )
 			{
 
@@ -199,7 +198,7 @@ if ( isset($_GET['op']) )
 		if ( isset($_GET['id']) )
 		{
 			//PreInit these values 
-			$content['VIEWID'] = DB_RemoveBadChars($_GET['id']);
+			$content['VIEWID'] = intval($_GET['id']);
 
 			// Get UserInfo
 			$result = DB_Query("SELECT DisplayName FROM " . DB_VIEWS . " WHERE ID = " . $content['VIEWID'] ); 
@@ -318,7 +317,7 @@ if ( isset($content['ISEDITORNEWVIEW']) && $content['ISEDITORNEWVIEW'] )
 // --- Process POST Form Data
 if ( isset($_POST['op']) )
 {
-	if ( isset ($_POST['id']) ) { $content['VIEWID'] = DB_RemoveBadChars($_POST['id']); } else {$content['VIEWID'] = ""; }
+	if ( isset ($_POST['id']) && is_scalar($_POST['id']) ) { $content['VIEWID'] = intval($_POST['id']); } else {$content['VIEWID'] = 0; }
 	if ( isset ($_POST['DisplayName']) ) { $content['DisplayName'] = DB_StripSlahes($_POST['DisplayName']); } else {$content['DisplayName'] = ""; }
 
 	// User & Group handeled specially

--- a/src/convert.php
+++ b/src/convert.php
@@ -77,7 +77,7 @@ $content['TITLE'] = "LogAnalyzer :: " . $content['LN_CONVERT_TITLE'];
 // --- Read Vars
 if ( isset($_GET['step']) )
 {
-	$content['CONVERT_STEP'] = intval(DB_RemoveBadChars($_GET['step']));
+	$content['CONVERT_STEP'] = intval($_GET['step']);
 	if ( $content['CONVERT_STEP'] > MAX_STEPS ) 
 		$content['CONVERT_STEP'] = 1;
 }

--- a/src/include/functions_db.php
+++ b/src/include/functions_db.php
@@ -99,6 +99,10 @@ function DB_Connect()
 		DB_PrintError("Cannot use database '" .GetConfigSetting("UserDBName") . "'", true);
 	// :D Success connecting to db
 
+	// Charset for correct mysqli_real_escape_string behaviour and full Unicode
+	if ( !@mysqli_set_charset($userdbconn, 'utf8mb4') )
+		@mysqli_set_charset($userdbconn, 'utf8');
+
 	// TODO Do some more validating on the database
 }
 
@@ -262,6 +266,27 @@ function DB_RemoveParserSpecialBadChars($myString)
 	return $returnstr;
 }
 
+/*
+ * Escape a string for use in a single-quoted SQL literal on the active MySQL connection.
+ * Falls back to addslashes() if the user DB is disabled or not connected yet (e.g. install).
+ */
+function DB_EscapeMysqlString($myValue)
+{
+	global $userdbconn;
+
+	if ( $myValue === null )
+		$myValue = '';
+	elseif ( is_scalar($myValue) )
+		$myValue = (string)$myValue;
+	else
+		$myValue = '';
+
+	if ( GetConfigSetting("UserDBEnabled", false) == true && $userdbconn instanceof mysqli )
+		return mysqli_real_escape_string($userdbconn, $myValue);
+
+	return addslashes($myValue);
+}
+
 function DB_RemoveBadChars($myValue, $dbEngine = DB_MYSQL, $bForceStripSlahes = false)
 {
 	// Check if Array
@@ -277,8 +302,7 @@ function DB_RemoveBadChars($myValue, $dbEngine = DB_MYSQL, $bForceStripSlahes = 
 			}
 			else
 			{
-				// Replace with internal PHP Functions!
-				$retArray[$mykey] = addslashes($myString);
+				$retArray[$mykey] = DB_EscapeMysqlString($myString);
 			}
 		}
 
@@ -295,8 +319,7 @@ function DB_RemoveBadChars($myValue, $dbEngine = DB_MYSQL, $bForceStripSlahes = 
 		}
 		else
 		{
-			// Replace with internal PHP Functions!
-			return addslashes($myValue);
+			return DB_EscapeMysqlString($myValue);
 		}
 	}
 }

--- a/src/install.php
+++ b/src/install.php
@@ -74,7 +74,7 @@ $content['TITLE'] = "LogAnalyzer :: " . $content['LN_INSTALL_TITLE'];
 // --- Read Vars
 if ( isset($_GET['step']) )
 {
-	$content['INSTALL_STEP'] = intval(DB_RemoveBadChars($_GET['step']));
+	$content['INSTALL_STEP'] = intval($_GET['step']);
 	if ( $content['INSTALL_STEP'] > MAX_STEPS ) 
 		$content['INSTALL_STEP'] = 1;
 }
@@ -301,7 +301,7 @@ else if ( $content['INSTALL_STEP'] == 4 )
 				RevertOneStep( $content['INSTALL_STEP']-1, $content['LN_CFG_PARAMMISSING'] . $content['LN_CFG_DBSERVER'] );
 
 			if ( isset($_POST['UserDBPort']) )
-				$_SESSION['UserDBPort'] = intval(DB_RemoveBadChars($_POST['UserDBPort']));
+				$_SESSION['UserDBPort'] = intval($_POST['UserDBPort']);
 			else
 				RevertOneStep( $content['INSTALL_STEP']-1, $content['LN_CFG_PARAMMISSING'] . $content['LN_CFG_DBPORT'] );
 
@@ -326,12 +326,12 @@ else if ( $content['INSTALL_STEP'] == 4 )
 				$_SESSION['UserDBPass'] = "";
 
 			if ( isset($_POST['UserDBLoginRequired']) )
-				$_SESSION['UserDBLoginRequired'] = intval(DB_RemoveBadChars($_POST['UserDBLoginRequired']));
+				$_SESSION['UserDBLoginRequired'] = intval($_POST['UserDBLoginRequired']);
 			else
 				$_SESSION['UserDBLoginRequired'] = false;
 
 			if ( isset($_POST['UserDBAuthMode']) )
-				$_SESSION['UserDBAuthMode'] = intval(DB_RemoveBadChars($_POST['UserDBAuthMode']));
+				$_SESSION['UserDBAuthMode'] = intval($_POST['UserDBAuthMode']);
 			else
 				$_SESSION['UserDBAuthMode'] = USERDB_AUTH_INTERNAL;
 			
@@ -344,7 +344,7 @@ else if ( $content['INSTALL_STEP'] == 4 )
 				else
 					RevertOneStep( $content['INSTALL_STEP']-1, $content['LN_CFG_PARAMMISSING'] . $content['LN_CFG_LDAPServer'] );
 				if ( isset($_POST['LDAPPort']) )
-					$_SESSION['LDAPPort'] = intval(DB_RemoveBadChars($_POST['LDAPPort']));
+					$_SESSION['LDAPPort'] = intval($_POST['LDAPPort']);
 				else
 					RevertOneStep( $content['INSTALL_STEP']-1, $content['LN_CFG_PARAMMISSING'] . $content['LN_CFG_LDAPPort'] );
 				if ( isset($_POST['LDAPBaseDN']) )
@@ -389,7 +389,7 @@ else if ( $content['INSTALL_STEP'] == 4 )
 	// --- Read Frontend Vars
 	if ( isset($_POST['ViewMessageCharacterLimit']) )
 	{
-		$_SESSION['ViewMessageCharacterLimit'] = intval( DB_RemoveBadChars($_POST['ViewMessageCharacterLimit']) );
+		$_SESSION['ViewMessageCharacterLimit'] = intval($_POST['ViewMessageCharacterLimit']);
 		if ( $_SESSION['ViewMessageCharacterLimit'] < 0 )
 			$_SESSION['ViewMessageCharacterLimit'] = 80; // Fallback default!
 	}
@@ -398,7 +398,7 @@ else if ( $content['INSTALL_STEP'] == 4 )
 
 	if ( isset($_POST['ViewStringCharacterLimit']) )
 	{
-		$_SESSION['ViewStringCharacterLimit'] = intval( DB_RemoveBadChars($_POST['ViewStringCharacterLimit']) );
+		$_SESSION['ViewStringCharacterLimit'] = intval($_POST['ViewStringCharacterLimit']);
 		if ( $_SESSION['ViewStringCharacterLimit'] < 0 )
 			$_SESSION['ViewStringCharacterLimit'] = 30; // Fallback default!
 	}
@@ -407,7 +407,7 @@ else if ( $content['INSTALL_STEP'] == 4 )
 
 	if ( isset($_POST['ViewEntriesPerPage']) )
 	{
-		$_SESSION['ViewEntriesPerPage'] = intval( DB_RemoveBadChars($_POST['ViewEntriesPerPage']) );
+		$_SESSION['ViewEntriesPerPage'] = intval($_POST['ViewEntriesPerPage']);
 		if ( $_SESSION['ViewEntriesPerPage'] < 0 )
 			$_SESSION['ViewEntriesPerPage'] = 50; // Fallback default!
 	}
@@ -415,12 +415,12 @@ else if ( $content['INSTALL_STEP'] == 4 )
 		$_SESSION['ViewEntriesPerPage'] = 50; // Fallback default!
 
 	if ( isset($_POST['ViewEnableDetailPopups']) )
-		$_SESSION['ViewEnableDetailPopups'] = intval( DB_RemoveBadChars($_POST['ViewEnableDetailPopups']) );
+		$_SESSION['ViewEnableDetailPopups'] = intval($_POST['ViewEnableDetailPopups']);
 	else
 		$_SESSION['ViewEnableDetailPopups'] = 1; // Fallback default!
 
 	if ( isset($_POST['EnableIPAddressResolve']) )
-		$_SESSION['EnableIPAddressResolve'] = intval( DB_RemoveBadChars($_POST['EnableIPAddressResolve']) );
+		$_SESSION['EnableIPAddressResolve'] = intval($_POST['EnableIPAddressResolve']);
 	else
 		$_SESSION['EnableIPAddressResolve'] = 1; // Fallback default!
 


### PR DESCRIPTION
Summary:
- Addresses CVE-2023-34600 / GitHub issue #102 (SQL injection via unquoted admin IDs) and supersedes the approach in PR #104: every user-supplied value that is concatenated into SQL as a bare number now uses intval() on GET/POST (and alternate params such as dbmpid, savedreportid) for users, groups, charts, searches, sources, views, DB mappings, and saved-report row IDs.
- String/TEXT identifiers are not cast with intval(): FieldID and ParserID stay DB_RemoveBadChars + quoted SQL; report module ReportID / reportid stay string keys into PHP report maps; only the numeric DB row id (SavedReportID) is intval’d where SQL uses WHERE ID = … unquoted.
- Admin request plumbing fixes include users.php POST edituser id, reports savedreportid paths, dbmappings dbmpid (GET edit/delete + POST), views.php edit/delete VIEWID and corrected edit branching; sources cleardata/dbstats SOURCEID intval; charts/sources edit paths align with intval array keys.
- Redundant intval(DB_RemoveBadChars(…)) was simplified to intval(…) across src (admin + convert + install) where only integer coercion matters.
- Hardening for quoted literals: functions_db.php adds DB_EscapeMysqlString(), wires DB_RemoveBadChars() (and thus PrepareValueForDB()) to mysqli_real_escape_string when UserDBEnabled and a mysqli connection exist, else addslashes fallback; DB_Connect() sets utf8mb4 with utf8 fallback so escaping matches client charset.
