### PR TITLE
Fix PHP 8 date() timestamp casts (fixes #132)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@ Version 5.0.2, 2026-05-05
 - Robustness & i18n
   - **`DieWithErrorMsg` / `DieWithFriendlyErrorMsg`**: fix invalid extra `<tr>` in the auxiliary error table; normalise detail rows; correct friendly-error footer cell markup; trim redundant padding `<br>` in error cells ([`functions_common.php`](src/include/functions_common.php)).
   - Export placeholder copy: strip decorative **`&gt;` / `&lt;`** from **`LN_GEN_SELECTEXPORT`** in en/de/es/ja `main.php`.
+  - PHP 8.1+: cast event timestamps to **`int`** before **`date()`** in disk consolidation/chart helpers, grid date formatting, DB/PDO/ClickHouse date-range filters, and export filenames; fix wrong field variable in disk **`ConsolidateItemListByField`** / **`ConsolidateDataByField`** date grouping ([#132](https://github.com/rsyslog/loganalyzer/issues/132), thanks **@KDocProf**).
 - E2E / Playwright
   - **`Modern theme visual review`**: switch session style via `userchange.php`, assert theme stylesheets, capture **`modern-01`…`modern-05`** screenshots under `e2e/test-results/ci-visual/` (index grid, **details dialog**, admin index, advanced search, reports).
 

--- a/src/classes/logstreamclickhouse.class.php
+++ b/src/classes/logstreamclickhouse.class.php
@@ -1518,20 +1518,20 @@ class LogStreamClickHouse extends LogStream {
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_TO ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_DATE ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
-																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", ($myeventtime[EVTIME_TIMESTAMP]+86400) ) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
+																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP] + 86400 ) . "'";
 									}
 
 									break;

--- a/src/classes/logstreamdb.class.php
+++ b/src/classes/logstreamdb.class.php
@@ -1547,20 +1547,20 @@ class LogStreamDB extends LogStream {
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_TO ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_DATE ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
-																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", ($myeventtime[EVTIME_TIMESTAMP]+86400) ) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
+																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP] + 86400 ) . "'";
 									}
 
 									break;

--- a/src/classes/logstreamdisk.class.php
+++ b/src/classes/logstreamdisk.class.php
@@ -821,7 +821,7 @@ class LogStreamDisk extends LogStream {
 					if ( $nConsFieldType == FILTER_TYPE_DATE ) 
 					{
 						// Convert to FULL Day Date for now!
-						$myFieldData = date( "Y-m-d", $logArray[$szFieldId][EVTIME_TIMESTAMP] );
+						$myFieldData = date( "Y-m-d", (int)$logArray[$szConsFieldId][EVTIME_TIMESTAMP] );
 					}
 					else // Just copy the value!
 						$myFieldData = $logArray[$szConsFieldId];
@@ -914,7 +914,7 @@ class LogStreamDisk extends LogStream {
 					if ( $nConsFieldType == FILTER_TYPE_DATE ) 
 					{
 						// Convert to FULL Day Date for now!
-						$myFieldData = date( "Y-m-d", $logArray[$szFieldId][EVTIME_TIMESTAMP] );
+						$myFieldData = date( "Y-m-d", (int)$logArray[$szConsFieldId][EVTIME_TIMESTAMP] );
 					}
 					else // Just copy the value!
 						$myFieldData = $logArray[$szConsFieldId];
@@ -1017,7 +1017,7 @@ class LogStreamDisk extends LogStream {
 					if ( $nFieldType == FILTER_TYPE_DATE ) 
 					{
 						// Convert to FULL Day Date for now!
-						$myFieldData = date( "Y-m-d", $logArray[$szFieldId][EVTIME_TIMESTAMP] );
+						$myFieldData = date( "Y-m-d", (int)$logArray[$szFieldId][EVTIME_TIMESTAMP] );
 					}
 					else // Just copy the value!
 						$myFieldData = $logArray[$szFieldId];

--- a/src/classes/logstreampdo.class.php
+++ b/src/classes/logstreampdo.class.php
@@ -1852,20 +1852,20 @@ class LogStreamPDO extends LogStream {
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_TO ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "'";
 									}
 									else if ( $myfilter[FILTER_DATEMODE] == DATEMODE_RANGE_DATE ) 
 									{
 										// Obtain Event struct for the time!
 										$myeventtime = GetEventTime($myfilter[FILTER_VALUE]);
-										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", $myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
-																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", ($myeventtime[EVTIME_TIMESTAMP]+86400) ) . "'";
+										$tmpfilters[$propertyname][FILTER_VALUE] .= $dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " > '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP]) . "' AND " . 
+																					$dbmapping[$szTableType]['DBMAPPINGS'][$propertyname] . " < '" . date("Y-m-d H:i:s", (int)$myeventtime[EVTIME_TIMESTAMP] + 86400 ) . "'";
 									}
 
 									break;

--- a/src/export.php
+++ b/src/export.php
@@ -400,7 +400,7 @@ else
 	$szOutputCharset = "";
 
 	$szOutputFileName = isset($content['period_start_ts'])
-		? "ExportMessages_" . date('Ymd\THis', $content['period_start_ts']) . "-" . date('Ymd\THis', $content['period_end_ts'])
+		? "ExportMessages_" . date('Ymd\THis', (int)$content['period_start_ts']) . "-" . date('Ymd\THis', (int)$content['period_end_ts'])
 		: "ExportMessages";
 	$szOutputFileExtension = ".txt";
 	$szOPFieldSeparator = " ";

--- a/src/include/functions_frontendhelpers.php
+++ b/src/include/functions_frontendhelpers.php
@@ -230,14 +230,14 @@ function GetFormatedDate($evttimearray, $onExport = false)
 			($onExport == true && GetConfigSetting("ExportUseTodayYesterday", 0, CFGLEVEL_USER) == 1)   
 			|| ( 
 				$onExport == false && GetConfigSetting("ViewUseTodayYesterday", 0, CFGLEVEL_USER) == 1 
-				&& ( date('m', $evttimearray[EVTIME_TIMESTAMP]) == date('m') && date('Y', $evttimearray[EVTIME_TIMESTAMP]) == date('Y') )
+				&& ( date('m', (int)$evttimearray[EVTIME_TIMESTAMP]) == date('m') && date('Y', (int)$evttimearray[EVTIME_TIMESTAMP]) == date('Y') )
 			 )
 		  )	
 		{
-			if ( date('d', $evttimearray[EVTIME_TIMESTAMP]) == date('d') )
-				return "Today " . date("H:i:s", $evttimearray[EVTIME_TIMESTAMP] );
-			else if ( date('d', $evttimearray[EVTIME_TIMESTAMP] + 86400) == date('d') )
-				return "Yesterday " . date("H:i:s", $evttimearray[EVTIME_TIMESTAMP] );
+			if ( date('d', (int)$evttimearray[EVTIME_TIMESTAMP]) == date('d') )
+				return "Today " . date("H:i:s", (int)$evttimearray[EVTIME_TIMESTAMP] );
+			else if ( date('d', (int)$evttimearray[EVTIME_TIMESTAMP] + 86400) == date('d') )
+				return "Yesterday " . date("H:i:s", (int)$evttimearray[EVTIME_TIMESTAMP] );
 		}
 		
 		// Copy to local variable
@@ -251,7 +251,7 @@ function GetFormatedDate($evttimearray, $onExport = false)
 	}
 
 	// Reach return normal format!
-	return $szDateFormatted = date("Y-m-d H:i:s", $nMyTimeStamp );
+	return $szDateFormatted = date("Y-m-d H:i:s", (int)$nMyTimeStamp );
 }
 
 function GetDebugBgColor( $szDebugMode )


### PR DESCRIPTION
Cast event timestamps to int before date() for PHP 8.1+

PHP 8.1+ requires an integer for date()'s timestamp parameter. Passing
numeric strings (or other non-int values) from event-time arrays triggers
deprecation notices; PHP 8.4+ can throw TypeError. This broke disk-source
statistics/charts reported in #132 and could affect other code paths that
format EVTIME_TIMESTAMP values without casting.

Disk logstream (logstreamdisk.class.php)
- ConsolidateItemListByField: cast (int) on EVTIME_TIMESTAMP; fix wrong
  variable $szFieldId -> $szConsFieldId when grouping by date fields
- ConsolidateDataByField: same variable fix and (int) cast
- GetCountSortedByField: (int) cast (chartgenerator.php / #132 trigger path)

Grid display (functions_frontendhelpers.php)
- GetFormatedDate: cast all date() timestamp args derived from
  $evttimearray[EVTIME_TIMESTAMP], +86400 expressions, and $nMyTimeStamp

Search filters (logstreamdb/pdo/clickhouse.class.php)
- DATEMODE_RANGE_FROM / RANGE_TO / RANGE_DATE: cast (int) on
  $myeventtime[EVTIME_TIMESTAMP] before building SQL date literals

Export (export.php)
- Cast (int) on period_start_ts / period_end_ts in export filename

ChangeLog: document fix under 5.0.2 Robustness; credit @KDocProf.

Fixes #132