### PR TITLE
security: bump pymdown-extensions to 11.0.1 for CVE-2026-67422

### DIFF
--- a/doc-site/requirements.txt
+++ b/doc-site/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material>=9.5,<10
-pymdown-extensions>=10,<11
+mkdocs-material>=9.7,<10
+pymdown-extensions>=11.0.1,<12


### PR DESCRIPTION
Dependabot alert #9 flagged a high-severity ReDoS (GHSA-gm37-52c6-37mw) in pymdown-extensions 11.0.0 and older. The handbook pin was 10.x only, which could never install the 11.0.1 patch and there is no 10.x security release.

Raise pymdown-extensions to 11.0.1 or newer (below 12) and mkdocs-material to 9.7 or newer (below 10). Material 9.5/9.6 still require pymdown-extensions 10.x, so the 9.7 floor is required for a consistent resolver. This is the MkDocs GitHub Pages toolchain only; the PHP application and Docker images are unaffected.

